### PR TITLE
Add more entity placements and default render method for unknown entities.

### DIFF
--- a/Starforge.Vanilla/Entities/CrystalSpinner.cs
+++ b/Starforge.Vanilla/Entities/CrystalSpinner.cs
@@ -8,12 +8,13 @@ namespace Starforge.Vanilla.Entities {
     [EntityDefinition("spinner")]
     public class CrystalSpinner : Entity {
 
-        DrawableTexture Sprite = GFX.Gameplay["danger/crystal/fg_blue03"];
+        DrawableTexture Sprite;
 
         public CrystalSpinner(Level level, EntityData data) : base(level, data) {
 
             if(data.GetBool("dust")) {
                 // Dust bunny
+                Sprite = GFX.Gameplay["danger/dustcreature/base00"];
             } else {
                 switch(data.GetString("color").ToLower()) {
                     case "red":

--- a/Starforge.Vanilla/Entities/Feather.cs
+++ b/Starforge.Vanilla/Entities/Feather.cs
@@ -1,0 +1,25 @@
+﻿using Starforge.Core;
+using Starforge.MapStructure;
+using Starforge.Mod;
+using Starforge.Mod.Assets;
+
+namespace Starforge.Vanilla.Entities
+{
+    [EntityDefinition("infiniteStar")]
+    public class Feather : Entity
+    {
+        private static readonly DrawableTexture Sprite = GFX.Gameplay["objects/flyFeather/idle00"];
+
+        public Feather(Level level, EntityData data) : base(level, data) { }
+
+        public override void Render()
+        {
+            Sprite.DrawCentered(Position);
+            if (GetBool("shielded", false)) {
+                // TODO: Circle
+                //Draw.Circle(Position, 10f, Color.White, 3);
+            }
+        }
+    }
+}
+

--- a/Starforge.Vanilla/Entities/Jumpthru.cs
+++ b/Starforge.Vanilla/Entities/Jumpthru.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.Xna.Framework;
+using Starforge.Core;
+using Starforge.MapStructure;
+using Starforge.Mod;
+using Starforge.Mod.Assets;
+using Starforge.Util;
+
+namespace Starforge.Vanilla.Entities {
+    [EntityDefinition("jumpThru")]
+    public class Jumpthru : Entity {
+        public Jumpthru(Level level, EntityData data) : base(level, data) { }
+
+        public override void Render() {
+            string type = GetString("texture", "wood");
+            DrawableTexture baseTexture = GFX.Gameplay["objects/jumpthru/" + (type == "default" ? "wood" : type)];
+            int textureTiles = baseTexture.Width / 8;
+
+            int width = GetInt("width", 8);
+            int columns = width / 8;
+
+            for (int i = 0; i < columns; i++) {
+                int xOffset, yOffset;
+
+                if (i == 0) {
+                    // left side
+                    xOffset = 0;
+                    if (Position.Y >= 0 && (int)Position.Y < Level.Height && Position.X >= 8 && Position.X < Level.Width)
+                        yOffset = Level.ForegroundTiles[(int)(Position.X / 8) - 1, (int)Position.Y / 8] == '0' ? 1 : 0;
+                    else
+                        yOffset = 1;
+                }
+                else if (i == columns - 1) {
+                    // right side
+                    xOffset = textureTiles - 1;
+                    if (Position.Y >= 0 && (int)Position.Y < Level.Height && Position.X >= 0 && (Position.X + width) < Level.Width-1)
+                        yOffset = Level.ForegroundTiles[(int)((Position.X + width) / 8), (int)Position.Y / 8] == '0' ? 1 : 0;
+                    else
+                        yOffset = 1;
+                }
+                else {
+                    // middle
+                    xOffset = 1 + MiscHelper.Rand.Next(textureTiles - 2);
+                    yOffset = MiscHelper.Rand.Next(0, 2);
+                }
+                // Draw the sprite
+                new DrawableTexture(baseTexture, xOffset * 8, yOffset * 8, 8, 8).Draw(new Vector2(Position.X + (i * 8), Position.Y));
+            }
+        }
+    }
+}

--- a/Starforge.Vanilla/Entities/Lightning.cs
+++ b/Starforge.Vanilla/Entities/Lightning.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Xna.Framework;
+using Starforge.Core;
+using Starforge.MapStructure;
+using Starforge.Mod;
+using Starforge.Util;
+
+namespace Starforge.Vanilla.Entities
+{
+    [EntityDefinition("lightning")]
+    public class Lightning : Entity {
+        private static readonly Color BgColor = MiscHelper.HexToColor("fcf579") * 0.2f;
+        private static readonly Color OutlineColor = MiscHelper.HexToColor("fcf579");
+        public Lightning(Level level, EntityData data) : base(level, data) { }
+
+        public override void Render() {
+            Rectangle renderPos = new Rectangle((int)Position.X, (int)Position.Y, GetInt("width", 8), GetInt("height", 8));
+
+            GFX.Pixel.Draw(renderPos, BgColor);
+            GFX.Draw.HollowRectangle(renderPos, OutlineColor);
+        }
+    }
+}

--- a/Starforge.Vanilla/Entities/Refill.cs
+++ b/Starforge.Vanilla/Entities/Refill.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Xna.Framework;
+using Starforge.Core;
+using Starforge.MapStructure;
+using Starforge.Mod;
+using Starforge.Mod.Assets;
+
+namespace Starforge.Vanilla.Entities {
+    [EntityDefinition("refill")]
+    public class Refill : Entity {
+        private static readonly DrawableTexture OneDashSprite = GFX.Gameplay["objects/refill/idle00"];
+        private static readonly DrawableTexture TwoDashSprite = GFX.Gameplay["objects/refillTwo/idle00"];
+
+        public Refill(Level level, EntityData data) : base(level, data) { }
+
+        public override void Render() {
+            DrawableTexture texture = GetBool("twoDash", false) ? TwoDashSprite : OneDashSprite;
+            texture.DrawOutlineCentered(Position, Color.Black);
+            texture.DrawCentered(Position);
+        }
+    }
+}

--- a/Starforge.Vanilla/Starforge.Vanilla.csproj
+++ b/Starforge.Vanilla/Starforge.Vanilla.csproj
@@ -43,7 +43,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Entities\CrystalSpinner.cs" />
+    <Compile Include="Entities\Feather.cs" />
+    <Compile Include="Entities\Jumpthru.cs" />
+    <Compile Include="Entities\Lightning.cs" />
     <Compile Include="Entities\Player.cs" />
+    <Compile Include="Entities\Refill.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Starforge/MapStructure/Entity.cs
+++ b/Starforge/MapStructure/Entity.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Starforge.Core;
 using Starforge.MapStructure.Encoding;
 using Starforge.Mod;
 using System.Collections.Generic;
@@ -81,8 +83,16 @@ namespace Starforge.MapStructure {
     }
 
     public class UnknownEntity : Entity {
+        private static readonly Color BgColor = Color.Cyan * 0.2f;
+        private static readonly Color OutlineColor = Color.Cyan;
+
         public UnknownEntity(Level level, EntityData data) : base(level, data) { }
 
-        public override void Render() { }
+        public override void Render() {
+            // default width/height of 4 for non-rectangular entities works pretty well
+            Rectangle renderPos = new Rectangle((int)Position.X, (int)Position.Y, GetInt("width", 4), GetInt("height", 4));
+            GFX.Pixel.Draw(renderPos, BgColor);
+            GFX.Draw.HollowRectangle(renderPos, OutlineColor);
+        }
     }
 }

--- a/Starforge/Mod/Assets/DrawableTexture.cs
+++ b/Starforge/Mod/Assets/DrawableTexture.cs
@@ -93,6 +93,13 @@ namespace Starforge.Mod.Assets {
             Engine.Batch.Draw(Texture.Texture, position, NullableClipRect, Color.White, 0f, Center - DrawOffset, scale, SpriteEffects.None, 0f);
         }
 
+        public void DrawOutlineCentered(Vector2 position, Color color, int offset = 1) {
+            Engine.Batch.Draw(Texture.Texture, position + new Vector2(-offset, -offset), NullableClipRect, color, 0f, Center - DrawOffset, 1f, SpriteEffects.None, 0f);
+            Engine.Batch.Draw(Texture.Texture, position + new Vector2(-offset, offset), NullableClipRect, color, 0f, Center - DrawOffset, 1f, SpriteEffects.None, 0f);
+            Engine.Batch.Draw(Texture.Texture, position + new Vector2(offset, -offset), NullableClipRect, color, 0f, Center - DrawOffset, 1f, SpriteEffects.None, 0f);
+            Engine.Batch.Draw(Texture.Texture, position + new Vector2(offset, offset), NullableClipRect, color, 0f, Center - DrawOffset, 1f, SpriteEffects.None, 0f);
+        }
+
         public Rectangle GetRelativeRect(int x, int y, int w, int h) {
             int x0 = (int)(ClipRect.X - DrawOffset.X + x);
             int y0 = (int)(ClipRect.Y - DrawOffset.Y + y);


### PR DESCRIPTION
Adds Lightning, Jumpthrus, Refills and Feathers
Adds a default render method for entities not yet implemented.
Dust bunnies now render properly. (instead of rendering as a normal spinner)
Added DrawOutlineCentered to DrawableTexture - draws an outline of the DrawableTexture. Used a few times in Celeste (in Refills for example), so it's worth implementing. As silly as the implementation looks (drawing the texture 4 times), it's already more optimal than the base game (by unrolling the loop).

Feathers still need a function that draws a circle, in order to draw their shield.
Dust bunnies are nigh-invisible in dark environments. It would be nice to have an outline around them (like in-game), however DrawOutline doesn't work on pitch-black textures.