### PR TITLE
Add support for tools to be loaded from external plugins.

### DIFF
--- a/Starforge.Vanilla/Actions/TileAction.cs
+++ b/Starforge.Vanilla/Actions/TileAction.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Xna.Framework;
+using Starforge.Editor;
+using Starforge.Editor.Actions;
 using Starforge.Editor.Render;
 using Starforge.Editor.Tools;
 using Starforge.Map;
 using System.Collections.Generic;
 
-namespace Starforge.Editor.Actions {
+namespace Starforge.Vanilla.Actions {
     public abstract class TileAction : EditorAction {
         protected ToolLayer Layer { get; }
         protected short Tileset;
@@ -25,8 +27,6 @@ namespace Starforge.Editor.Actions {
             if (t == 0) Tileset = TileGrid.TILE_AIR;
             else Tileset = (short)Tiler.GetTilesetList()[t - 1].ID;
         }
-
-        public abstract ToolType GetToolType();
 
         public override bool Undo() {
             bool changed = false;

--- a/Starforge.Vanilla/Actions/TileBrushAction.cs
+++ b/Starforge.Vanilla/Actions/TileBrushAction.cs
@@ -3,7 +3,7 @@ using Starforge.Editor.Tools;
 using Starforge.Map;
 using System.Collections.Generic;
 
-namespace Starforge.Editor.Actions {
+namespace Starforge.Vanilla.Actions {
     public class TileBrushAction : TileAction {
         private HashSet<Point> Points;
 
@@ -30,7 +30,5 @@ namespace Starforge.Editor.Actions {
             if (changed) DrawableRoom.Dirty = true;
             return changed;
         }
-
-        public override ToolType GetToolType() => ToolType.TileBrush;
     }
 }

--- a/Starforge.Vanilla/Actions/TileRectangleAction.cs
+++ b/Starforge.Vanilla/Actions/TileRectangleAction.cs
@@ -2,7 +2,7 @@
 using Starforge.Editor.Tools;
 using Starforge.Map;
 
-namespace Starforge.Editor.Actions {
+namespace Starforge.Vanilla.Actions {
     public class TileRectangleAction : TileAction {
         private Rectangle Area;
 
@@ -43,7 +43,5 @@ namespace Starforge.Editor.Actions {
             if (changed) DrawableRoom.Dirty = true;
             return changed;
         }
-
-        public override ToolType GetToolType() => ToolType.TileRectangle;
     }
 }

--- a/Starforge.Vanilla/Tools/EntityTool.cs
+++ b/Starforge.Vanilla/Tools/EntityTool.cs
@@ -1,12 +1,23 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ImGuiNET;
+using Microsoft.Xna.Framework;
 using Starforge.Core;
+using Starforge.Editor;
 using Starforge.Editor.Actions;
+using Starforge.Editor.Tools;
 using Starforge.Map;
+using Starforge.Mod;
+using Starforge.Mod.API;
 using Starforge.Util;
 using System;
 
-namespace Starforge.Editor.Tools {
+namespace Starforge.Vanilla.Tools {
+    [ToolDefinition("Entity")]
     public class EntityTool : Tool {
+        /// <summary>
+        /// The currently selected entity placement.
+        /// </summary>
+        public static Placement SelectedEntity;
+
         public Entity HeldEntity;
 
         private Point Start;
@@ -15,13 +26,16 @@ namespace Starforge.Editor.Tools {
         private Rectangle Hold = new Rectangle(-64, -64, 0, 0);
 
         public override string GetName() => "Entities";
-
+        public override bool CanSelectLayer() => false;
         public override void Render() {
             if (HeldEntity != null) HeldEntity.Render();
         }
 
         public override void Update() {
             Room r = MapEditor.Instance.State.SelectedRoom;
+
+            if (SelectedEntity == null)
+                SelectedEntity = EntityRegistry.EntityPlacements[0];
 
             if (HeldEntity != null) {
                 HeldEntity.Room = r;
@@ -31,13 +45,13 @@ namespace Starforge.Editor.Tools {
                 else if (Input.Mouse.LeftUnclick) HandleUnclick();
                 else HandleMove();
             } else {
-                HeldEntity = ToolManager.SelectedEntity.Create(r);
+                HeldEntity = SelectedEntity.Create(r);
                 HeldEntity.SetArea(Hold);
             }
         }
 
         public void UpdateHeldEntity() {
-            HeldEntity = ToolManager.SelectedEntity.Create(MapEditor.Instance.State.SelectedRoom);
+            HeldEntity = SelectedEntity.Create(MapEditor.Instance.State.SelectedRoom);
             HeldEntity.SetArea(Hold);
         }
 
@@ -68,7 +82,7 @@ namespace Starforge.Editor.Tools {
         private void HandleUnclick() {
             HeldEntity.SetArea(Hold);
 
-            Entity entity = ToolManager.SelectedEntity.Create(MapEditor.Instance.State.SelectedRoom);
+            Entity entity = SelectedEntity.Create(MapEditor.Instance.State.SelectedRoom);
             if (HeldEntity.StretchableX || HeldEntity.StretchableY) entity.SetArea(Hold);
             else entity.Position = HeldEntity.Position;
 
@@ -84,6 +98,23 @@ namespace Starforge.Editor.Tools {
         private void HandleMove() {
             Hold = new Rectangle(MapEditor.Instance.State.TilePointer.X * 8, MapEditor.Instance.State.TilePointer.Y * 8, 8, 8);
             HeldEntity.SetArea(Hold);
+        }
+
+        public override void RenderGUI() {
+            ImGui.Text("Entities");
+            ImGui.SetNextItemWidth(235f);
+
+            if (SelectedEntity == null)
+                SelectedEntity = EntityRegistry.EntityPlacements[0];
+
+            if (ImGui.ListBoxHeader("EntitiesList", EntityRegistry.EntityPlacements.Count, MapEditor.Instance.ToolListWindow.VisibleItemsCount)) {
+                foreach (Placement placement in EntityRegistry.EntityPlacements) {
+                    if (ImGui.Selectable(placement.Name, placement == SelectedEntity)) {
+                        SelectedEntity = placement;
+                        UpdateHeldEntity();
+                    }
+                }
+            }
         }
     }
 }

--- a/Starforge.Vanilla/Tools/TileBrushTool.cs
+++ b/Starforge.Vanilla/Tools/TileBrushTool.cs
@@ -1,10 +1,15 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ImGuiNET;
+using Microsoft.Xna.Framework;
 using Starforge.Core;
-using Starforge.Editor.Actions;
+using Starforge.Editor;
+using Starforge.Editor.Tools;
 using Starforge.Map;
+using Starforge.Mod.API;
 using Starforge.Mod.Content;
+using Starforge.Vanilla.Actions;
 
-namespace Starforge.Editor.Tools {
+namespace Starforge.Vanilla.Tools {
+    [ToolDefinition("TileBrush")]
     public class TileBrushTool : Tool {
         /// <remarks>The hint is set out of bounds (beyond upleft corner) so the hint does not appear when first selecting the tool.</remarks>
         private Rectangle Hint = new Rectangle(-8, -8, 8, 8);
@@ -12,11 +17,16 @@ namespace Starforge.Editor.Tools {
         private TileBrushAction Action = null;
 
         public override string GetName() => "Tiles (Brush)";
+        public override bool CanSelectLayer() => true;
 
         public override void Render() {
             GFX.Draw.BorderedRectangle(Hint, Settings.ToolColor * 0.5f, Settings.ToolColor);
             Hint.X = MapEditor.Instance.State.TilePointer.X * 8;
             Hint.Y = MapEditor.Instance.State.TilePointer.Y * 8;
+        }
+
+        public override void RenderGUI() {
+            CreateGUITileTool();
         }
 
         public override void Update() {
@@ -48,6 +58,27 @@ namespace Starforge.Editor.Tools {
 
         private void HandleUnclick() {
             Action = null;
+        }
+
+        internal static void CreateGUITileTool() {
+            ImGui.Text("Tilesets");
+            ImGui.SetNextItemWidth(235f);
+            var toolListWindow = MapEditor.Instance.ToolListWindow;
+            if (ToolManager.SelectedLayer == ToolLayer.Background) {
+                if (ImGui.ListBoxHeader("TilesetsList", toolListWindow.BGTilesets.Count, toolListWindow.VisibleItemsCount)) {
+                    for (int i = 0; i < toolListWindow.BGTilesets.Count; i++) {
+                        if (ImGui.Selectable(toolListWindow.BGTilesets[i], ToolManager.BGTileset == i)) ToolManager.BGTileset = i;
+                    }
+                    ImGui.ListBoxFooter();
+                }
+            } else {
+                if (ImGui.ListBoxHeader("TilesetsList", toolListWindow.FGTilesets.Count, toolListWindow.VisibleItemsCount)) {
+                    for (int i = 0; i < toolListWindow.FGTilesets.Count; i++) {
+                        if (ImGui.Selectable(toolListWindow.FGTilesets[i], ToolManager.FGTileset == i)) ToolManager.FGTileset = i;
+                    }
+                    ImGui.ListBoxFooter();
+                }
+            }
         }
     }
 }

--- a/Starforge.Vanilla/Tools/TileBrushTool.cs
+++ b/Starforge.Vanilla/Tools/TileBrushTool.cs
@@ -1,33 +1,16 @@
-﻿using ImGuiNET;
-using Microsoft.Xna.Framework;
-using Starforge.Core;
+﻿using Starforge.Core;
 using Starforge.Editor;
 using Starforge.Editor.Tools;
 using Starforge.Map;
 using Starforge.Mod.API;
-using Starforge.Mod.Content;
 using Starforge.Vanilla.Actions;
 
 namespace Starforge.Vanilla.Tools {
     [ToolDefinition("TileBrush")]
-    public class TileBrushTool : Tool {
-        /// <remarks>The hint is set out of bounds (beyond upleft corner) so the hint does not appear when first selecting the tool.</remarks>
-        private Rectangle Hint = new Rectangle(-8, -8, 8, 8);
-
+    public class TileBrushTool : TileTool {
         private TileBrushAction Action = null;
 
         public override string GetName() => "Tiles (Brush)";
-        public override bool CanSelectLayer() => true;
-
-        public override void Render() {
-            GFX.Draw.BorderedRectangle(Hint, Settings.ToolColor * 0.5f, Settings.ToolColor);
-            Hint.X = MapEditor.Instance.State.TilePointer.X * 8;
-            Hint.Y = MapEditor.Instance.State.TilePointer.Y * 8;
-        }
-
-        public override void RenderGUI() {
-            CreateGUITileTool();
-        }
 
         public override void Update() {
             if (Input.Mouse.LeftClick) HandleClick();
@@ -58,27 +41,6 @@ namespace Starforge.Vanilla.Tools {
 
         private void HandleUnclick() {
             Action = null;
-        }
-
-        internal static void CreateGUITileTool() {
-            ImGui.Text("Tilesets");
-            ImGui.SetNextItemWidth(235f);
-            var toolListWindow = MapEditor.Instance.ToolListWindow;
-            if (ToolManager.SelectedLayer == ToolLayer.Background) {
-                if (ImGui.ListBoxHeader("TilesetsList", toolListWindow.BGTilesets.Count, toolListWindow.VisibleItemsCount)) {
-                    for (int i = 0; i < toolListWindow.BGTilesets.Count; i++) {
-                        if (ImGui.Selectable(toolListWindow.BGTilesets[i], ToolManager.BGTileset == i)) ToolManager.BGTileset = i;
-                    }
-                    ImGui.ListBoxFooter();
-                }
-            } else {
-                if (ImGui.ListBoxHeader("TilesetsList", toolListWindow.FGTilesets.Count, toolListWindow.VisibleItemsCount)) {
-                    for (int i = 0; i < toolListWindow.FGTilesets.Count; i++) {
-                        if (ImGui.Selectable(toolListWindow.FGTilesets[i], ToolManager.FGTileset == i)) ToolManager.FGTileset = i;
-                    }
-                    ImGui.ListBoxFooter();
-                }
-            }
         }
     }
 }

--- a/Starforge.Vanilla/Tools/TileRectangleTool.cs
+++ b/Starforge.Vanilla/Tools/TileRectangleTool.cs
@@ -1,10 +1,14 @@
 ﻿using Microsoft.Xna.Framework;
 using Starforge.Core;
-using Starforge.Editor.Actions;
+using Starforge.Editor;
+using Starforge.Editor.Tools;
 using Starforge.Map;
+using Starforge.Mod.API;
 using Starforge.Mod.Content;
+using Starforge.Vanilla.Actions;
 
-namespace Starforge.Editor.Tools {
+namespace Starforge.Vanilla.Tools {
+    [ToolDefinition("TileRectangle")]
     public class TileRectangleTool : Tool {
         /// <remarks>The hint is set out of bounds (beyond upleft corner) so the hint does not appear when first selecting the tool.</remarks>
         private Rectangle Hint = new Rectangle(-8, -8, 8, 8);
@@ -13,6 +17,7 @@ namespace Starforge.Editor.Tools {
         private Point Start;
 
         public override string GetName() => "Tiles (Rectangle)";
+        public override bool CanSelectLayer() => true;
 
         public override void Render() {
             GFX.Draw.BorderedRectangle(Hint, Settings.ToolColor * 0.5f, Settings.ToolColor);
@@ -72,6 +77,10 @@ namespace Starforge.Editor.Tools {
             Hold = new Rectangle(MapEditor.Instance.State.TilePointer.X, MapEditor.Instance.State.TilePointer.Y, 1, 1);
             Hint.Width = 8;
             Hint.Height = 8;
+        }
+
+        public override void RenderGUI() {
+            TileBrushTool.CreateGUITileTool();
         }
     }
 }

--- a/Starforge.Vanilla/Tools/TileRectangleTool.cs
+++ b/Starforge.Vanilla/Tools/TileRectangleTool.cs
@@ -4,26 +4,15 @@ using Starforge.Editor;
 using Starforge.Editor.Tools;
 using Starforge.Map;
 using Starforge.Mod.API;
-using Starforge.Mod.Content;
 using Starforge.Vanilla.Actions;
 
 namespace Starforge.Vanilla.Tools {
     [ToolDefinition("TileRectangle")]
-    public class TileRectangleTool : Tool {
-        /// <remarks>The hint is set out of bounds (beyond upleft corner) so the hint does not appear when first selecting the tool.</remarks>
-        private Rectangle Hint = new Rectangle(-8, -8, 8, 8);
-
+    public class TileRectangleTool : TileTool {
         private Rectangle Hold = new Rectangle(-1, -1, 0, 0);
         private Point Start;
 
         public override string GetName() => "Tiles (Rectangle)";
-        public override bool CanSelectLayer() => true;
-
-        public override void Render() {
-            GFX.Draw.BorderedRectangle(Hint, Settings.ToolColor * 0.5f, Settings.ToolColor);
-            Hint.X = MapEditor.Instance.State.TilePointer.X * 8;
-            Hint.Y = MapEditor.Instance.State.TilePointer.Y * 8;
-        }
 
         public override void Update() {
             if (Input.Mouse.LeftClick) HandleClick();
@@ -77,10 +66,6 @@ namespace Starforge.Vanilla.Tools {
             Hold = new Rectangle(MapEditor.Instance.State.TilePointer.X, MapEditor.Instance.State.TilePointer.Y, 1, 1);
             Hint.Width = 8;
             Hint.Height = 8;
-        }
-
-        public override void RenderGUI() {
-            TileBrushTool.CreateGUITileTool();
         }
     }
 }

--- a/Starforge.Vanilla/Tools/TileTool.cs
+++ b/Starforge.Vanilla/Tools/TileTool.cs
@@ -1,0 +1,46 @@
+﻿using ImGuiNET;
+using Microsoft.Xna.Framework;
+using Starforge.Core;
+using Starforge.Editor;
+using Starforge.Editor.Tools;
+using Starforge.Mod.Content;
+
+namespace Starforge.Vanilla.Tools {
+    /// <summary>
+    /// A base class for any tile-based tools. Implements Render, RenderGUI and CanSelectLayer.
+    /// </summary>
+    public abstract class TileTool : Tool {
+        /// <remarks>The hint is set out of bounds (beyond upleft corner) so the hint does not appear when first selecting the tool.</remarks>
+        protected Rectangle Hint = new Rectangle(-8, -8, 8, 8);
+
+        public override bool CanSelectLayer() => true;
+
+        public override void Render() {
+            GFX.Draw.BorderedRectangle(Hint, Settings.ToolColor * 0.5f, Settings.ToolColor);
+            // While this might look like a mistake, setting Hint after Rendering fixes a huge visual bug with the Rectangle Tool
+            Hint.X = MapEditor.Instance.State.TilePointer.X * 8;
+            Hint.Y = MapEditor.Instance.State.TilePointer.Y * 8;
+        }
+
+        public override void RenderGUI() {
+            ImGui.Text("Tilesets");
+            ImGui.SetNextItemWidth(235f);
+            var toolListWindow = MapEditor.Instance.ToolListWindow;
+            if (ToolManager.SelectedLayer == ToolLayer.Background) {
+                if (ImGui.ListBoxHeader("TilesetsList", toolListWindow.BGTilesets.Count, toolListWindow.VisibleItemsCount)) {
+                    for (int i = 0; i < toolListWindow.BGTilesets.Count; i++) {
+                        if (ImGui.Selectable(toolListWindow.BGTilesets[i], ToolManager.BGTileset == i)) ToolManager.BGTileset = i;
+                    }
+                    ImGui.ListBoxFooter();
+                }
+            } else {
+                if (ImGui.ListBoxHeader("TilesetsList", toolListWindow.FGTilesets.Count, toolListWindow.VisibleItemsCount)) {
+                    for (int i = 0; i < toolListWindow.FGTilesets.Count; i++) {
+                        if (ImGui.Selectable(toolListWindow.FGTilesets[i], ToolManager.FGTileset == i)) ToolManager.FGTileset = i;
+                    }
+                    ImGui.ListBoxFooter();
+                }
+            }
+        }
+    }
+}

--- a/Starforge/Editor/MapEditor.cs
+++ b/Starforge/Editor/MapEditor.cs
@@ -25,7 +25,7 @@ namespace Starforge.Editor {
 
         // Windows and UI elements
         internal WindowRoomList RoomListWindow;
-        internal WindowToolList ToolListWindow;
+        public WindowToolList ToolListWindow;
         private ShortcutManager Shortcuts;
 
         public bool AcceptToolInput { get; private set; } = false;

--- a/Starforge/Editor/ToolManager.cs
+++ b/Starforge/Editor/ToolManager.cs
@@ -15,7 +15,11 @@ namespace Starforge.Editor {
         /// <summary>
         /// The currently selected tool.
         /// </summary>
-        public static Tool SelectedTool;
+        public static Tool SelectedTool {
+            get => _selectedTool ??= Tools["TileBrush"];
+            set => _selectedTool = value;
+        }
+        private static Tool _selectedTool;
 
         /// <summary>
         /// The currently selected tool layer (background/foreground).
@@ -42,14 +46,10 @@ namespace Starforge.Editor {
         }
 
         public static void Render() {
-            if (SelectedTool == null)
-                SelectedTool = Tools["TileBrush"];
             SelectedTool.Render();
         }
 
         public static void Update() {
-            if (SelectedTool == null)
-                SelectedTool = Tools["TileBrush"];
             SelectedTool.Update();
         }
 

--- a/Starforge/Editor/Tools/Tool.cs
+++ b/Starforge/Editor/Tools/Tool.cs
@@ -3,16 +3,12 @@
         public abstract string GetName();
         public abstract void Update();
         public abstract void Render();
+        public abstract void RenderGUI();
+        public abstract bool CanSelectLayer();
     }
 
     public enum ToolLayer {
         Background,
         Foreground
-    }
-
-    public enum ToolType {
-        TileBrush,
-        TileRectangle,
-        Entity
     }
 }

--- a/Starforge/Mod/API/DefinitionAttributes.cs
+++ b/Starforge/Mod/API/DefinitionAttributes.cs
@@ -32,4 +32,16 @@ namespace Starforge.Mod.API {
     public class TriggerDefinitionAttribute : EntityDefinitionAttribute {
         public TriggerDefinitionAttribute(string name) : base(name) { }
     }
+
+    /// <summary>
+    /// Used to identify a tool.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class ToolDefinitionAttribute : Attribute {
+        public ToolDefinitionAttribute(string name) {
+            ID = name;
+        }
+
+        public readonly string ID;
+    }
 }

--- a/Starforge/Mod/EntityRegistry.cs
+++ b/Starforge/Mod/EntityRegistry.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace Starforge.Mod {
     public static class EntityRegistry {
-        private static List<Placement> EntityPlacements;
+        public static List<Placement> EntityPlacements;
         private static Dictionary<string, EntityCreator> EntityCreators;
 
         static EntityRegistry() {

--- a/Starforge/Mod/Loader.cs
+++ b/Starforge/Mod/Loader.cs
@@ -1,4 +1,6 @@
 ﻿using Starforge.Core;
+using Starforge.Editor;
+using Starforge.Editor.Tools;
 using Starforge.Map;
 using Starforge.Mod.API;
 using System;
@@ -24,6 +26,14 @@ namespace Starforge.Mod {
                         if (type.GetCustomAttribute<EntityDefinitionAttribute>() != null || type.GetCustomAttribute<TriggerDefinitionAttribute>() != null) {
                             EntityRegistry.Register(type);
                         } else {
+                            Logger.Log(LogLevel.Warning, $"Assembly {asm.GetName()} contains {type} without an appropriate definition attribute");
+                        }
+                    }
+                    if (type.IsSubclassOf(typeof(Tool))) {
+                        if (type.GetCustomAttribute<ToolDefinitionAttribute>() != null) {
+                            ToolManager.Register(type);
+                        }
+                        else {
                             Logger.Log(LogLevel.Warning, $"Assembly {asm.GetName()} contains {type} without an appropriate definition attribute");
                         }
                     }

--- a/Starforge/Mod/Loader.cs
+++ b/Starforge/Mod/Loader.cs
@@ -6,6 +6,7 @@ using Starforge.Mod.API;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Starforge.Mod {
@@ -21,7 +22,7 @@ namespace Starforge.Mod {
         /// <param name="asm">The assembly to load.</param>
         public static void LoadPluginAssembly(Assembly asm) {
             try {
-                foreach (Type type in asm.GetTypes()) {
+                foreach (Type type in asm.GetTypes().Where((type) => !type.IsAbstract)) {
                     if (type.IsSubclassOf(typeof(Entity))) {
                         if (type.GetCustomAttribute<EntityDefinitionAttribute>() != null || type.GetCustomAttribute<TriggerDefinitionAttribute>() != null) {
                             EntityRegistry.Register(type);


### PR DESCRIPTION
Add support for tools to be loaded from external plugins.

To demonstrate this, all Starforge tools and related Actions got moved into `Starforge.Vanilla`.
`ToolManager.SelectedEntity` got moved into `EntityTool`, as it really shouldn't be in `ToolManager`.
`ToolManager.BGTileset` and `FGTileset` didn't get moved, as they can be useful for tile-based entity placements (so that they use the currently selected tileset)
The `ToolTypes` enum got removed, as enums aren't extendable by plugins. Instead, string ID's are used.

To register a Tool, the class extending Tool needs to contain the new `ToolDefinition` Attribute.
Tools now have an `abstact bool CanSelectLayer()`, which determines whether the layer selection menu should appear when the tool is selected. Replaces hardcoded enum checks.
Tools now have an `abstact void RenderGUI()`, which renders the GUI sidebar (usually containing placement options), instead of hardcoding it in `WindowToolList`